### PR TITLE
direct approaches for embedding and step2, removing most library().

### DIFF
--- a/R/check2D.R
+++ b/R/check2D.R
@@ -18,12 +18,11 @@
 #'
 #' @export
 
-Similaritycheck <- function(clusters, normcounts, dimred, fig=F) {
+Similaritycheck <- function(clusters, dimred, fig=F) {
 
   dimred <- as.data.frame(dimred)
-  dimred <- dimred[colnames(normcounts),]
   cut_avg <- clusters$Clusters
-  cut_avg <- cut_avg[colnames(normcounts)]
+  cut_avg <- cut_avg[rownames(dimred)]
   K <- clusters$K
 
   knn_index <- FNN::get.knn(dimred, k=3)$nn.index
@@ -32,7 +31,7 @@ Similaritycheck <- function(clusters, normcounts, dimred, fig=F) {
   knn_overlap <- apply(knn_df, 1, function(x) sum(x[2:4]!=x[1]))
   t_knn <- table(knn_overlap)
 
-  good_rate <- sum(t_knn[as.numeric(names(t_knn))<=1])/ncol(normcounts)
+  good_rate <- sum(t_knn[as.numeric(names(t_knn))<=1])/nrow(dimred)
 
   if(fig) {
     plotcol <- as.numeric(as.factor(cut_avg))

--- a/R/server.R
+++ b/R/server.R
@@ -1,13 +1,3 @@
-library(mclust)
-library(scales)
-library(slingshot)
-library(DT)
-library(shinyjs)
-library(dplyr)
-library(clusterProfiler)
-library(edgeR)
-library(magrittr)
-
 server <- function(input, output) {
   # # add image:
   # output$home_img <- renderImage({
@@ -20,16 +10,49 @@ server <- function(input, output) {
   # step0:
   rawcounts <- reactive({
     req(input$rawfile)
-    mat <- read.csv(input$rawfile$datapath, row.names=1)
-    as.matrix(mat)
+    tryCatch({
+      if (grepl("\\.csv$", tolower(input$rawfile$name), ignore.case = TRUE)) {
+        mat <- read.csv(input$rawfile$datapath, row.names = 1)
+        as.matrix(mat)
+      } else if (grepl("\\.rds$", tolower(input$rawfile$name), ignore.case = TRUE)) {
+        mat <- readRDS(input$rawfile$datapath)
+        if(!is.matrix(mat)) {
+          stop("The RDS file must contain a matrix.")
+        }
+        mat
+      } else {
+        stop("Unsupported file format. Please upload a .csv or .rds file.")
+      }
+    }, error = function(e) {
+      showNotification(e$message, type = "error")
+      NULL
+    })
   })
+  
+  
 
   normcounts <- reactive({
     req(input$normfile)
-    mat <- read.csv(input$normfile$datapath, row.names=1)
-    as.matrix(mat)
+    tryCatch({
+      if (grepl("\\.csv$", tolower(input$normfile$name), ignore.case = TRUE)) {
+        mat <- read.csv(input$normfile$datapath, row.names = 1)
+        as.matrix(mat)
+      } else if (grepl("\\.rds$", tolower(input$normfile$name), ignore.case = TRUE)) {
+        mat <- readRDS(input$normfile$datapath)
+        if(!is.matrix(mat)) {
+          stop("The RDS file must contain a matrix.")
+        }
+        mat
+      } else {
+        stop("Unsupported file format. Please upload a .csv or .rds file.")
+      }
+    }, error = function(e) {
+      showNotification(e$message, type = "error")
+      NULL
+    })
   })
-
+ 
+  
   # begin analysis
   mydf <- reactiveValues(
     raw = NULL,
@@ -48,7 +71,7 @@ server <- function(input, output) {
     mydf$norm <- NULL
     mydf$from <- FALSE
   })
-
+  
   output$no_genes <- renderValueBox({
     if(mydf$from) {
       valueBox(
@@ -66,15 +89,15 @@ server <- function(input, output) {
       )
     }
   })
-
+  
   output$uploadnote <- renderText({
     if(mydf$from) return("Datasets verified. Begin analysis.")
     if(!mydf$from) return("No datasets detected.")
-    })
-
-
+  })
+  
+  
   output$no_cells <- renderValueBox({
-
+    
     if(mydf$from) {
       valueBox(
         value = ncol(mydf$norm),
@@ -91,6 +114,7 @@ server <- function(input, output) {
       )
     }
   })
+  
 
 
   # Test DC in HighDim:
@@ -100,6 +124,8 @@ server <- function(input, output) {
     raw_mat <- mydf$raw
     HD_DCClusterscheck(normcounts=norm_mat, rawcounts=raw_mat, clust.max = 5)
   })
+  
+ 
 
   output$step1_dc <- renderText({
     if(!mydf$from & is.null(step1_test2())) return(NULL)
@@ -109,6 +135,19 @@ server <- function(input, output) {
            making trajectory fitting inappropriate. To aid in defining these diverse cell types,
            we present the results of the differential expression (DE) analysis between clusters.")
   })
+  
+  #save the result from step 1:
+  output$downloadStep1Results <- downloadHandler(
+    # Define the filename of the download
+    filename = function() {
+      paste("step_1_results", Sys.Date(), ".rds", sep = "")
+    },
+    content = function(file) {
+      req(step1_test2())
+      saveRDS(step1_test2(), file)
+    }
+  )
+  
 
   # DE in DC clusters:
   step1_de <- reactive({
@@ -124,7 +163,7 @@ server <- function(input, output) {
     if(!mydf$from) return(NULL)
     if(is.null(step1_test2())) return(NULL)
     if(step1_test2()$ifConnected) return(NULL)
-    datatable(step1_de(),rownames = F, filter = 'top')%>%
+    DT::datatable(step1_de(),rownames = F, filter = 'top')%>%
       DT::formatStyle(names(step1_de()),lineHeight='80%')
   })
 
@@ -135,6 +174,8 @@ server <- function(input, output) {
     norm_mat <- mydf$norm
     step1_testHomogeneous(normcounts=norm_mat, num.sim = 1000)
   })
+  
+ 
 
   output$step1_homogeneous <- renderText({
     if(!mydf$from) return(NULL)
@@ -158,7 +199,7 @@ server <- function(input, output) {
     if(!mydf$from) return(NULL)
     if(is.null(step1_test1())) return(NULL)
     if(step1_test1()$signal_pct>=0.46) return(NULL)
-    datatable(step1_hvgs(),rownames = TRUE, filter = 'top')%>%
+    DT::datatable(step1_hvgs(),rownames = TRUE, filter = 'top')%>%
       DT::formatStyle(names(step1_de()),lineHeight='80%')
   })
 
@@ -184,7 +225,7 @@ server <- function(input, output) {
     if(is.null(step1_test1())) return(NULL)
     if(step1_test1()$signal_pct>=0.46) return(NULL)
     if(is.null(step1_go())) return(NULL)
-    datatable(step1_go(),rownames = TRUE, filter = 'top',
+    DT::datatable(step1_go(),rownames = TRUE, filter = 'top',
               options = list(
                 autoWidth = TRUE,scrollX=TRUE,
                 columnDefs = list(list(width = '400px', targets = c(2)),
@@ -195,9 +236,12 @@ server <- function(input, output) {
 
   # step1_decision
   step1_res <- reactive({
-    if(!mydf$from) return(NULL)
-    step1_test1()$signal_pct>=0.46 && step1_test2()$ifConnecte
+    if(!mydf$from)return(NULL)
+    step1_test1()$signal_pct>=0.46 && (step1_test2()$ifConnected)
   })
+  
+ 
+  
 
   output$step1_decision <- renderText({
     if(!mydf$from) return(NULL)
@@ -234,53 +278,96 @@ server <- function(input, output) {
     legend("topleft", legend=as.character(1:K), col=c(1:K), pch=16, cex = 0.5)
 
   })
-
-
-
-  # generate the obj
-  safegenes <- reactive({
-    if(is.null(input$normfile) || !mydf$from) {
-      return(NULL)
-    }
-    
-    max_genes <- nrow(mydf$norm)
-    
-    validated_genes <-NULL
-    
-    if(is.na(input$checkgenes) || is.null(input$checkgenes)) {
-      validated_genes <- 10
-      showNotification("No input detected or input is invalid. Defaulting to 10 genes.", type = "message")
-    } else {
-      validated_genes <- min(max(input$checkgenes, 10), max_genes)
-      
-      if(input$checkgenes != validated_genes) {
-        if(input$checkgenes < 10) {
-          showNotification("Input is below the minimum allowed number (10). Adjusted to 10.", type = "message")
-        } else if(input$checkgenes > max_genes) {
-          showNotification("Input exceeds the maximum number of genes. Adjusted to maximum available.", type = "message")
+  
+  
+  #optional for uploading norm data in embedding
+  normalcounts <- reactive({
+    req(input$normalfile)
+    tryCatch({
+      if (grepl("\\.csv$", tolower(input$normalfile$name), ignore.case = TRUE)) {
+        mat <- read.csv(input$normalfile$datapath, row.names = 1)
+        as.matrix(mat)
+      } else if (grepl("\\.rds$", tolower(input$normalfile$name), ignore.case = TRUE)) {
+        mat <- readRDS(input$normalfile$datapath)
+        if(!is.matrix(mat)) {
+          stop("The RDS file must contain a matrix.")
         }
+        mat
+      } else {
+        stop("Unsupported file format. Please upload a .csv or .rds file.")
       }
-    }
-    
-    return(validated_genes)
+    }, error = function(e) {
+      showNotification(e$message, type = "error")
+      NULL
+    })
   })
   
   
+
+  observeEvent(input$normalfile, {
+    optional_normal_file <- normalcounts()
+    if(!is.null(optional_normal_file)) {
+      mydf$norml <- optional_normal_file
+      mydf$readyForEmbedding <- TRUE  
+    } else {
+      mydf$readyForEmbedding <- FALSE
+    }
+  })
   
-  
-  
-  
+  #optional safegenes
+  safegenes <- reactive({
+    
+    req(isTRUE(mydf$readyForEmbedding) || !is.null(mydf$norm))
+    
+    
+    currentData <- if (!is.null(mydf$norm)) {
+      mydf$norm
+    } else if (!is.null(mydf$norml)) {
+      mydf$norml
+    } else {
+      return(NULL)  
+    }
+    
+    
+    max_genes <- nrow(currentData)
+    
+    validated_genes <- NULL
+    
+    if (is.na(input$checkgenes) || is.null(input$checkgenes)) {
+      validated_genes <- 10
+      showNotification("No inpit detected or input is invalid. Defaulting to 10 genes.", type = "message")
+    } else {
+      validated_genes <- min(max(input$checkgenes, 10), max_genes)
+    
+    # Notifications based on the outcome of `validated_genes`
+    if (input$checkgenes != validated_genes) {
+      if (input$checkgenes < 10) {
+        showNotification("Input is below the minimum allowed number (10). Adjusted to 10.", type = "message")
+      } else if (input$checkgenes > max_genes) {
+        showNotification("Input exceeds the maximum number of genes. Adjusted to maximum available.", type = "message")
+      }
+    }
+    }
+     return(validated_genes)
+  })
   
   
 
+  
   step23_obj <- reactive({
+    
+    req(isTRUE(mydf$readyForEmbedding) || !is.null(mydf$norm))
+    
+    
+   
+    currentData <- if (!is.null(mydf$norm)) mydf$norm else mydf$norml
+    
+    
     tryCatch({
-      if(is.null(input$normfile)) return(NULL)
-      if(!mydf$from) return(NULL)
-      # select genes:
-      gene.var <- quick_model_gene_var(mydf$norm)
+      # Select genes
+      gene.var <- quick_model_gene_var(currentData)
       genes.HVGs <- rownames(gene.var)[1:safegenes()]
-      sub_counts <- mydf$norm[genes.HVGs,]
+      sub_counts <- currentData[genes.HVGs,]
       # DR
       dimred <- getDR_2D(sub_counts, input$checkDR)
       # Trajectory
@@ -289,7 +376,7 @@ server <- function(input, output) {
       ti_out <- slingshot::slingshot(data=dimred, clusterLabels=cl1)
       rawpse <- slingshot::slingPseudotime(x=ti_out, na=T)
       pse <- as.data.frame(rawpse / max(rawpse, na.rm=TRUE))
-      ls_fitLine <- lapply(slingCurves(ti_out), function(x) x$s[x$ord,])
+      ls_fitLine <- lapply(slingshot::slingCurves(ti_out), function(x) x$s[x$ord,])
       fitLine <- do.call(rbind, lapply(ls_fitLine, function(x) {
         df_seg <- cbind(x[-nrow(x),],x[-1,])
         colnames(df_seg) <- c("x0", "y0", "x1", "y1")
@@ -302,19 +389,19 @@ server <- function(input, output) {
       showNotification(paste("The input number is invalid, minimum is 10:", e$message), type = "error")
       return(NULL)
     })
-    })
-    
-
+  })
+  
+  
   # colors obtained from brewer.pal(11,'Spectral')[-6]
   brewCOLS <- c("#9E0142", "#D53E4F", "#F46D43", "#FDAE61", "#FEE08B", "#E6F598", "#ABDDA4", "#66C2A5", "#3288BD", "#5E4FA2")
-
+  
   # plot the trajectory
   output$trajectory_plot <- renderPlot({
     if(is.null(step23_obj())) return(NULL)
     colors <- colorRampPalette(brewCOLS)(100)
     pse <- step23_obj()$pse
     pse$Ave <- rowMeans(pse, na.rm = T)
-
+    
     Sys.sleep(1)
     plotcol <- colors[cut(pse$Ave, breaks=100)]
     plot(step23_obj()$Embedding, col = scales::alpha(plotcol, 0.7), pch=16, main="Estimated PT")
@@ -323,8 +410,8 @@ server <- function(input, output) {
              x1 = step23_obj()$fitLine$x1,
              y1 = step23_obj()$fitLine$y1, lwd = 3)
   }, height = 450, width=450)
-
-
+  
+  
   # download the obj
   rf2 <- reactiveValues()
   observe({
@@ -333,7 +420,7 @@ server <- function(input, output) {
         eval_obj <<- step23_obj()
       )
   })
-
+  
   output$downloadTraj <- downloadHandler(
     filename = function() {
       paste0(paste(input$checkDR, safegenes(), input$checkTraj, sep="_"), ".rds")
@@ -342,6 +429,10 @@ server <- function(input, output) {
       saveRDS(eval_obj, file = file)
     }
   )
+  
+  
+  
+  
 
   # load data files
   output$obj_files <- renderTable(input$objs[,1], colnames = F)
@@ -352,12 +443,47 @@ server <- function(input, output) {
       purrr::set_names(input$objs$name)
   })
 
+  HDDCcheck_upload <- reactive({
+    req(input$step1ResultsUpload)
+    tryCatch({
+      if (grepl("\\.rds$", tolower(input$step1ResultsUpload$name), ignore.case = TRUE)) {
+        mat <- readRDS(input$step1ResultsUpload$datapath)
+        
+        if (!is.null(mat)) {
+          return(mat)
+        } else {
+          showNotification("The RDS file does not contain valid data.", type = "error")
+          return(NULL)
+        }
+      } else {
+        stop("Unsupported file format. Please upload a .rds file.")
+      }
+    }, error = function(e) {
+      showNotification(e$message, type = "error")
+      NULL
+    })
+  })
+  
+  
+  
+  
+  #optional 
+  observeEvent(input$step1ResultsUpload, {
+    HDDCcheck_result <- HDDCcheck_upload()
+    if(!is.null(HDDCcheck_result)) {
+      mydf$result <- HDDCcheck_result
+  }
+    })
+
+  
+  
+
   # step2:
   # test DC in
-
+  
   step2_test1 <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     DRLvsC <- list()
     for (i in 1:length(all_files())) {
       subls <- all_files()[[i]]
@@ -365,53 +491,58 @@ server <- function(input, output) {
     }
     return(DRLvsC)
   })
-
+  
   # test similarity between HD and LD
   step2_test2 <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
+    clusters_data <- if (!is.null(mydf$result)) {
+      mydf$result
+    } else {
+      step1_test2()
+    }
     simi_cells <- list()
     for (i in 1:length(all_files())) {
       subls <- all_files()[[i]]
-      simi_cells[[names(all_files())[i]]] <- Similaritycheck(normcounts=mydf$norm, dimred=subls$Embedding, clusters=step1_test2())
+      simi_cells[[names(all_files())[i]]] <- Similaritycheck(dimred=subls$Embedding, clusters=clusters_data)
     }
     return(simi_cells)
   })
-
+  
   #summary:
   structure_tb <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     # norm_mat <- all_files()[[1]]$Normcounts
     dc_tb <- data.frame(data=names(step2_test1()), DCcheck=sapply(step2_test1(), function(x) x$ifConnected))
     simi_tb <- data.frame(data=names(step2_test2()), SimiRetain=sapply(step2_test2(), function(x) x$GoodRate))
     merge(dc_tb, simi_tb, by="data")
   })
-
+  
   output$step2_celltb <- renderTable({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     df <- structure_tb()[,c("data", "DCcheck")]
     df$" " <- ifelse(df$DCcheck, "√", "X")
-
+    
     Sys.sleep(1)
     df[order(df$data), ]
   }, digits = 3)
-
+  
   output$step2_simitb <- renderTable({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     df <- structure_tb()[,c("data", "SimiRetain")]
-
+    
     Sys.sleep(1)
     df[order(df$data), ]
   }, digits = 3)
-
-
+  
+  
   # test GOF
   step2_test4 <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     gof_eval <- list()
     for (i in 1:length(all_files())) {
       subls <- all_files()[[i]]
@@ -419,24 +550,24 @@ server <- function(input, output) {
     }
     return(gof_eval)
   })
-
+  
   output$step2_spreadtb <- renderTable({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     gof_tb <- data.frame(data=names(step2_test4()), GOF=sapply(step2_test4(), function(x) x$occupiedRate))
-
+    
     Sys.sleep(1)
     gof_tb[order(gof_tb$data), ]
   }, digits = 3)
-
-
+  
+  
   
   # step3:
   # test Ushape
-
+  
   step2_test3 <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     ushap_eval <- list()
     for (i in 1:length(all_files())) {
       subls <- all_files()[[i]]
@@ -444,21 +575,21 @@ server <- function(input, output) {
     }
     return(ushap_eval)
   })
-
+  
   output$step3_res <- renderTable({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     ushap_tb <- data.frame(data=names(step2_test3()), USHAPE=sapply(step2_test3(), function(x) x$Ambpct))
-
+    
     Sys.sleep(1)
     ushap_tb[order(ushap_tb$data), ]
   }, digits = 3)
-
+  
   # conclusion
   # combine all results
   final_tb <- reactive({
     if(is.null(all_files)) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     df <- structure_tb()
     if(!any(df$DCcheck)) return(NULL)
     # simi_tb <- data.frame(data=names(step2_test2()), SimiRetain=sapply(step2_test2(), function(x) x$GoodRate))
@@ -470,41 +601,41 @@ server <- function(input, output) {
     rownames(alldf) <- alldf$data
     alldf[,c("DCcheck", "SimiRetain", "GOF", "USHAPE")]
   })
-
-
-
-
+  
+  
+  
+  
   res_tb <- reactive({
     if(is.null(all_files)) return(NULL)
     if(is.null(final_tb())) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     scoredf <- final_tb()
     final_df <- calcScore(scoredf)
     return(final_df)
   })
-
+  
   output$final_res <- renderTable({
     if(is.null(all_files)) return(NULL)
     if(is.null(res_tb())) return(NULL)
-    if(is.null(step1_res())) return(NULL)
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
     res_tb()[,c("Row.names", "DCcheck", "SimiRetain", "GOF", "USHAPE", "score","ranking", "decision", "note")]
   }, digits = 3)
-
-
+  
+  
   output$final_plot <- renderPlot({
     if(is.null(all_files)) return(NULL)
     if(is.null(res_tb())) return(NULL)
-    if(is.null(step1_res())) return(NULL)
-
+    if(is.null(step1_res()) && is.null(mydf$result)) return(NULL)
+    
     df <- res_tb()
     df <- df[!is.na(df$score),]
-
+    
     df <- df[order(df$score, decreasing = T), ]
     data_plt <- head(df$Row.names, 6)
-
+    
     # colors obtained from brewer.pal(11,'Spectral')[-6]
     brewCOLS <- c("#9E0142", "#D53E4F", "#F46D43", "#FDAE61", "#FEE08B", "#E6F598", "#ABDDA4", "#66C2A5", "#3288BD", "#5E4FA2")
-
+    
     colors <- colorRampPalette(brewCOLS)(100)
     
     output$table <- downloadHandler(
@@ -519,7 +650,7 @@ server <- function(input, output) {
         write.csv(selected_data, file, row.names = FALSE)
       }
     )
-
+    
     Sys.sleep(1)
     par(mfrow = c(2, 3))
     for (i in data_plt) {
@@ -534,7 +665,7 @@ server <- function(input, output) {
                y1 = subls$fitLine$y1, lwd = 3)
     }
   })
-
-
-
+  
+  
+  
 }

--- a/R/ui.R
+++ b/R/ui.R
@@ -3,7 +3,7 @@ library(shinydashboard)
 library(shiny)
 library(shinyjs)
 library(shinycssloaders)
-library(magrittr)
+
 
 js <- '.nav-tabs-custom .nav-tabs li.active {
     border-top-color: #f39c12;
@@ -120,14 +120,16 @@ ui <- dashboardPage(
                            column(width = 6,
                                 br(),
                                 # read raw data after QC
-                                fileInput("rawfile", label = "Raw Data", buttonLabel = "Upload", accept = c(".csv")),
+                                fileInput("rawfile", label = "Raw Data", buttonLabel = "Upload", accept = c(".csv", ".rds")),
                                 # read norm data after QC
-                                fileInput("normfile", label = "Norm Data", buttonLabel = "Upload", accept = c(".csv")),
+                                fileInput("normfile", label = "Norm Data", buttonLabel = "Upload", accept = c(".csv", "rds")),
                                 actionButton("upload", "Import"),
                                 actionButton('reset', 'Clear'),#Clear input dataset#
                                 hr(),
                                 textOutput(outputId = "uploadnote"),
-                                hr()),
+                                hr(),
+                                hr(),
+                                downloadButton("downloadStep1Results", "Download Step 1 Results"),),
                          column(width = 6,
                                 br(),
                                 # h4(strong("Data Info:")),
@@ -177,10 +179,20 @@ ui <- dashboardPage(
                       br(),
                        downloadButton(outputId="downloadTraj", label = "Download .rds object")
                 ),
-                column(7, plotOutput("trajectory_plot")%>% withSpinner(color="#FAD02C"))
+                column(7, plotOutput("trajectory_plot")%>% withSpinner(color="#FAD02C")),
+                br(),
+                br(),
+                column(9, # New column for the upload button
+                       br(),
+                       br(),
+                       fileInput("normalfile", label = "Optional: Upload the Normalized Data", buttonLabel = "Upload", accept = c(".csv", "rds"))
+                       
+                       
+                     
 
-
-              )),
+               
+                
+              ))),
 
       tabItem(tabName = "step2",
 
@@ -206,9 +218,14 @@ ui <- dashboardPage(
                 column(width=3,
                        h4(strong("Load all embeddings: (multiple allowed)")),
                        fileInput("objs", label = NULL, buttonLabel = "Upload .rds file", accept = c(".rds"), multiple = TRUE),
-                       tableOutput("obj_files"))
-              )
-      ),
+                       tableOutput("obj_files"),
+                       fileInput("step1ResultsUpload", buttonLabel = "Upload .rds file", "Upload Step 1 Results", accept = ".rds")
+                       
+                       
+                )
+                
+              
+      )),
 
 
       tabItem(tabName = "step3",

--- a/man/Similaritycheck.Rd
+++ b/man/Similaritycheck.Rd
@@ -4,16 +4,16 @@
 \alias{Similaritycheck}
 \title{Structure Similarity between Orignal data and Embedding}
 \usage{
-Similaritycheck(clusters, normcounts, dimred, fig = F)
+Similaritycheck(clusters, dimred, fig = F)
 }
 \arguments{
 \item{clusters}{object from \code{DCClusterscheck} fucntion.}
 
-\item{normcounts}{a normalized count data matrix: row:genes, column:cells}
-
 \item{dimred}{A data frame. a 2D embedding from a DR method and the row name is the cell name.}
 
 \item{fig}{A figure showing the clusters identified in raw data in the embedding}
+
+\item{normcounts}{a normalized count data matrix: row:genes, column:cells}
 }
 \value{
 A list about the results of structure similarity check between high- and low- dimenaional data.


### PR DESCRIPTION
1. instructions on loading data in step 1 in shiny app, accept .csv, .rds.
2. added download button for step 1 HDDCcheck() result.
3. optional input data option in generate embedding tab for users to skip step 1 with only normalized data.
4. file upload button for step1 HDDCcheck() result for users to directly use step 2 with embeddings .rds files and step1 result .rds file.
5. removed requirement of normcounts from Similaritycheck.
6. instead of having library(package), and @importpackage, removed  library(package), added package:: for specific functions, and @importFrom for specific functions.