### PR TITLE
Remove reactivity for selection of DR methods for plotting graphs. Always show all 3 graphs without reloading/replotting the graphs on DR methods changing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: Escort
 Type: Package
 Title: Escort: Data-driven Selection of Trajectory
-Version: 0.1.6
+Version: 0.1.7
 Depends: R (>= 3.5.0)
 Authors@R: c(person("Xiaoru", "Dong", , "xdong1@ufl.edu", role = c("aut", "cre"), comment = c(ORCID = "0000-0003-3039-3004")), 
              person(given = "Rhonda", family = "Bacher", email = "rbacher@ufl.edu", role = c("ctb", "fnd"), comment = c(ORCID = "0000-0001-5787-476X")))

--- a/R/server.R
+++ b/R/server.R
@@ -363,8 +363,8 @@ server <- function(input, output) {
       genes.HVGs <- rownames(gene.var)[1:safegenes()]
       sub_counts <- currentData[genes.HVGs,]
 
-      #get all the DR methods in the form of a list which can be looped
-      dr_methods <- strsplit(input$drMethods, ", ")
+      #all types of dr method embeddings to be entered in the list
+      dr_methods <- c("MDS", "TSNE", "UMAP")
       #This list will contain list of objects (objects returned by the porpTraj method)
       #This list will also be returned
       list_object_to_return <- list()
@@ -439,63 +439,53 @@ server <- function(input, output) {
     # generate_embedding_plot utility function
     generate_embedding_plot("UMAP", temp_object$UMAP)
   }, height = 300, width = 300)
-  
-  
-  
-  # download the obj
-  rf2 <- reactiveValues()
-  observe({
-    if(!is.null(step23_obj()))
-      isolate(
-        eval_obj <<- step23_obj()
-      )
-  })
+
   
   output$downloadTraj <- downloadHandler(
     filename = function() {
       paste0(paste(safegenes(), input$checkTraj, sep="_"), ".rds")
     },
     content = function(file) {
-      saveRDS(eval_obj, file = file)
+      all_dr_types_embeddings_list <- step23_obj()
+      
+      #get all the user selected DR methods and store them in a list
+      dr_methods_list <- c()
+      if (!is.null(input$drMethods)) {
+        dr_methods_list <- strsplit(input$drMethods, ", ")
+      }
+      to_download <- list()
+
+      #loop through the umbrella list all_dr_types_embeddings_list
+      #which contains embedding object for all 3 types
+      #and only filter out the ones selected by the user
+      #push those items to a list to_download which will finally be downloaded
+      if(!is.null(all_dr_types_embeddings_list))
+        for(dr_method in dr_methods_list) {
+          to_download[[dr_method]] <- all_dr_types_embeddings_list[[dr_method]]
+        }
+      saveRDS(to_download, file = file)
     }
   )
 
   observe({
+      #by default initially keep the download button disabled
+      shinyjs::disable("downloadTraj")
+      
       dr_methods_string <- input$drMethods
-      # If none of the checkbox DR items are selected,then input$drMethods
-      # returns null
-      # Hence if it is null, disable the download button
-      if(is.null(dr_methods_string)) {
+      is_dr_methods_checkbox_empty <- is.null(dr_methods_string)
+      #check if input methods are selected and show a warning based on that
+      if(is_dr_methods_checkbox_empty) {
+        showNotification("At least one DR method needs to be selected.", type = "error", duration = 10)
+        shinyjs::disable("downloadTraj")
+        return(NULL)
+      }
+      #if the data is still not imported/ready then download button
+      #should be disabled
+      if(isFALSE(mydf$readyForEmbedding) || is.null(mydf$norm)) {
         shinyjs::disable("downloadTraj")
       } else {
-        #else enable the download button
+        # else enable the download button
         shinyjs::enable("downloadTraj")
-      }
-      
-      #the code below shows/hides the individual plots for
-      #MDS, TSNE, UMAP in the generate embeddings step
-      #this is done based on the checkbox items selected by the user
-      dr_methods_collapsed_string <- paste(input$drMethods, collapse = ", ")
-      if(grepl('MDS', dr_methods_collapsed_string, fixed = TRUE)) {
-        shinyjs::show("trajectory_plot_MDS_spinner")
-        shinyjs::show("trajectory_plot_MDS")
-      } else {
-        shinyjs::hide("trajectory_plot_MDS_spinner")
-        shinyjs::hide("trajectory_plot_MDS")
-      }
-      if(grepl('TSNE', dr_methods_collapsed_string, fixed = TRUE)) {
-        shinyjs::show("trajectory_plot_TSNE_spinner")
-        shinyjs::show("trajectory_plot_TSNE")
-      } else {
-        shinyjs::hide("trajectory_plot_TSNE_spinner")
-        shinyjs::hide("trajectory_plot_TSNE")
-      }
-      if(grepl('UMAP', dr_methods_collapsed_string, fixed = TRUE)) {
-        shinyjs::show("trajectory_plot_UMAP_spinner")
-        shinyjs::show("trajectory_plot_UMAP")
-      } else {
-        shinyjs::hide("trajectory_plot_UMAP_spinner")
-        shinyjs::hide("trajectory_plot_UMAP")
       }
     })
 
@@ -704,6 +694,17 @@ server <- function(input, output) {
   }, digits = 3)
   
   
+  output$table <- downloadHandler(
+      filename = function() {
+        paste("final_res", ".csv", sep="")
+      },
+      content = function(file) {
+        req(res_tb()) 
+        selected_data <- res_tb()[,c("Row.names", "DCcheck", "SimiRetain", "GOF", "USHAPE", "score", "ranking", "decision", "note")]
+        write.csv(selected_data, file, row.names = FALSE)
+      }
+    )
+  
   output$final_plot <- renderPlot({
     if(is.null(all_files)) return(NULL)
     if(is.null(res_tb())) return(NULL)
@@ -720,18 +721,6 @@ server <- function(input, output) {
     
     colors <- colorRampPalette(brewCOLS)(100)
     
-    output$table <- downloadHandler(
-      filename = function() {
-        paste("final_res", ".csv", sep="")
-      },
-      content = function(file) {
-        req(res_tb()) 
-        
-        selected_data <- res_tb()[,c("Row.names", "DCcheck", "SimiRetain", "GOF", "USHAPE", "score", "ranking", "decision", "note")]
-        
-        write.csv(selected_data, file, row.names = FALSE)
-      }
-    )
     
     Sys.sleep(1)
     par(mfrow = c(2, 3))

--- a/R/server.R
+++ b/R/server.R
@@ -477,18 +477,24 @@ server <- function(input, output) {
       #this is done based on the checkbox items selected by the user
       dr_methods_collapsed_string <- paste(input$drMethods, collapse = ", ")
       if(grepl('MDS', dr_methods_collapsed_string, fixed = TRUE)) {
+        shinyjs::show("trajectory_plot_MDS_spinner")
         shinyjs::show("trajectory_plot_MDS")
       } else {
+        shinyjs::hide("trajectory_plot_MDS_spinner")
         shinyjs::hide("trajectory_plot_MDS")
       }
       if(grepl('TSNE', dr_methods_collapsed_string, fixed = TRUE)) {
+        shinyjs::show("trajectory_plot_TSNE_spinner")
         shinyjs::show("trajectory_plot_TSNE")
       } else {
+        shinyjs::hide("trajectory_plot_TSNE_spinner")
         shinyjs::hide("trajectory_plot_TSNE")
       }
       if(grepl('UMAP', dr_methods_collapsed_string, fixed = TRUE)) {
+        shinyjs::show("trajectory_plot_UMAP_spinner")
         shinyjs::show("trajectory_plot_UMAP")
       } else {
+        shinyjs::hide("trajectory_plot_UMAP_spinner")
         shinyjs::hide("trajectory_plot_UMAP")
       }
     })

--- a/R/ui.R
+++ b/R/ui.R
@@ -58,7 +58,7 @@ ui <- dashboardPage(
       tabItem(tabName = "home",
               h3(strong("Welcome to Escort!")),
               fluidRow(
-                column(8,
+                column(12,
                        "Escort is a framework that evaluates
                        various data processing decisions in terms of their effect on trajectory inference
                        with single-cell RNA-seq data. Escort guides users
@@ -202,7 +202,7 @@ ui <- dashboardPage(
       tabItem(tabName = "step2",
 
               fluidRow(
-                column(width=6,
+                column(width=9,
                        box(
                          width=NULL, status = "primary", title = strong("Step 2: Evaluating the trajectory characteristics of embeddings"),
                          "Next, Escort identifies preferred embeddings for performing trajectory inference.
@@ -236,19 +236,19 @@ ui <- dashboardPage(
       tabItem(tabName = "step3",
               fluidRow(
                 box(
-                  width=6, status = "primary", title = strong("Step 3: Quantifying trajectory fitting performance"),
+                  width=12, status = "primary", title = strong("Step 3: Quantifying trajectory fitting performance"),
                   "Embeddings are also evaluated in the context of a trajectory inference method.
                 A preliminary trajectory in inferred and Escort assesses the proportion of cells having an ambiguous projection
                 to the trajectory. For example, trajectories in a U-shape tend to
                 be inaccurate because some cells will have map to opposing pseudotimes with equal probability.")),
               fluidRow(
-                box(width=6, title = "Percentage of ambiguous cells", status = "warning",
+                box(width=12, title = "Percentage of ambiguous cells", status = "warning",
                   tableOutput(outputId = "step3_res")%>% withSpinner(color="#FAD02C")))),
 
       tabItem(tabName = "conclusion",
               fluidRow(
                 box(
-                  width=9, status = "primary", title = strong("Escort suggestions for embedding selection"),
+                  width=12, status = "primary", title = strong("Escort suggestions for embedding selection"),
                   "Below is a table with each embedding's rating according to their overall performance. Embeddings with a score larger than zero are
                   Recommended for trajectoy inference.",
                   hr(),
@@ -257,7 +257,7 @@ ui <- dashboardPage(
               hr(),
               fluidRow(
                 box(
-                  width=9, status = "warning",
+                  width=12, status = "warning",
                   plotOutput("final_plot", height = "650px", width = "900px")%>% withSpinner(color="#FAD02C")))
               )
       )

--- a/R/ui.R
+++ b/R/ui.R
@@ -182,9 +182,9 @@ ui <- dashboardPage(
                       br(),
                       downloadButton(outputId="downloadTraj", label = "Download .rds object")
                 ),
-                column(3, plotOutput("trajectory_plot_MDS", height = 'auto')%>% withSpinner(color="#FAD02C")),
-                column(3, plotOutput("trajectory_plot_TSNE", height = 'auto')%>% withSpinner(color="#FAD02C")),
-                column(3, plotOutput("trajectory_plot_UMAP", height = 'auto')%>% withSpinner(color="#FAD02C")),
+                column(3, plotOutput("trajectory_plot_MDS", height = 'auto')%>% withSpinner(color="#FAD02C", id="trajectory_plot_MDS_spinner")),
+                column(3, plotOutput("trajectory_plot_TSNE", height = 'auto')%>% withSpinner(color="#FAD02C", id="trajectory_plot_TSNE_spinner")),
+                column(3, plotOutput("trajectory_plot_UMAP", height = 'auto')%>% withSpinner(color="#FAD02C", id="trajectory_plot_UMAP_spinner")),
                 br(),
                 br(),
                 column(9, # New column for the upload button


### PR DESCRIPTION
- Removed reactivity for graphs whenever DR method checkboxes are changed.
- Now showing all 3 plots at all times even if the DR methods keep changing.
- Made changes in such a way that step_23 object does not need to recalculate whenever checkboxes are changed. 
- It only recalculates when the input number is changes.
- The step23obj is calculated for all 3 types of DR method and stored in the step23 object.
- But while the user is downloading the rds file for the embeddings, it will only extract out the objects from that list which have been selected on the UI.